### PR TITLE
#6: Fixed default use of FakeService under a non-administrator account.

### DIFF
--- a/src/Hornbill/FakeService.fs
+++ b/src/Hornbill/FakeService.fs
@@ -71,7 +71,7 @@ type FakeService(port) =
     let createHost =
       fun name -> sprintf "http://%s:%i" name port
     url <- createHost "localhost"
-    webApp <- WebApp.Start(createHost "*", Middleware.app requests.Add findResponse setResponse requestReceived.Trigger)
+    webApp <- WebApp.Start(createHost "localhost", Middleware.app requests.Add findResponse setResponse requestReceived.Trigger)
     url
   
   [<Obsolete"Use Start()">]


### PR DESCRIPTION
Changed the listening hostname from "*" to "localhost" as that is exempt under newer versions of Windows from needing the URL to be granted permission by an administrator.
